### PR TITLE
Add --force-simplified option to control JSON report generation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "zhongkui",
-    version = "0.0.6",
+    version = "0.0.7",
 )
 
 # Bazel dependencies

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -626,7 +626,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "hdICB1K7PX7oWtO8oksVTBDNt6xxiNERpcO4Yxoa0Gc=",
-        "usagesDigest": "jayk82hLeyDQnwRpkIUOkQorDRGZw6kNOtPnTEtg9IU=",
+        "usagesDigest": "QM6vS+Ie4Kr+VlzRx2smfm2p6TDdZMIL4hv3Y1fGnzc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
- Add optional forceSimplified parameter to HotspotReporter.generateReport()
- Automatically generate simplified report when packageHotspots > 200
- Add --force-simplified CLI option to both analyze and run-and-analyze commands
- Optimize performance by skipping full report serialization when simplified report is needed
- Improve logging to show package count when generating simplified reports

This change addresses performance issues with very large build analyses where
JSON serialization can be slow or fail due to memory constraints.